### PR TITLE
Improve the performance of changing the composer mode.

### DIFF
--- a/features/messages/src/main/java/io/element/android/x/features/messages/MessagesScreen.kt
+++ b/features/messages/src/main/java/io/element/android/x/features/messages/MessagesScreen.kt
@@ -232,9 +232,9 @@ fun MessagesContent(
                 .imePadding()
                 .let {
                     if (composerFullScreen) {
-                        it.weight(1f)
+                        it.weight(1f, fill = false)
                     } else {
-                        it.height(COMPOSER_HEIGHT)
+                        it.wrapContentHeight(Alignment.Bottom)
                     }
                 },
         )

--- a/libraries/textcomposer/src/main/java/io/element/android/x/textcomposer/RichTextComposerLayout.kt
+++ b/libraries/textcomposer/src/main/java/io/element/android/x/textcomposer/RichTextComposerLayout.kt
@@ -66,6 +66,7 @@ class RichTextComposerLayout @JvmOverloads constructor(
     // There is no need to persist these values since they're always updated by the parent fragment
     private var isFullScreen = false
     private var hasRelatedMessage = false
+    private var composerMode: MessageComposerMode? = null
 
     var isTextFormattingEnabled = true
         set(value) {
@@ -118,9 +119,15 @@ class RichTextComposerLayout @JvmOverloads constructor(
 
     private val dimensionConverter = DimensionConverter(resources)
 
-    fun setFullScreen(isFullScreen: Boolean, manageKeyboard: Boolean) {
+    fun setFullScreen(isFullScreen: Boolean, animated: Boolean, manageKeyboard: Boolean) {
+        if (!animated && views.composerLayout.layoutParams != null) {
+            views.composerLayout.updateLayoutParams<ViewGroup.LayoutParams> {
+                height =
+                    if (isFullScreen) ViewGroup.LayoutParams.MATCH_PARENT else ViewGroup.LayoutParams.WRAP_CONTENT
+            }
+        }
         editText.updateLayoutParams<ViewGroup.LayoutParams> {
-            height = if (isFullScreen) 0 else ViewGroup.LayoutParams.WRAP_CONTENT
+            height = if (isFullScreen) ViewGroup.LayoutParams.MATCH_PARENT else ViewGroup.LayoutParams.WRAP_CONTENT
         }
 
         updateTextFieldBorder(isFullScreen)
@@ -141,6 +148,7 @@ class RichTextComposerLayout @JvmOverloads constructor(
                 editText.hideKeyboard()
             }
         }
+
         this.isFullScreen = isFullScreen
     }
 
@@ -466,6 +474,9 @@ class RichTextComposerLayout @JvmOverloads constructor(
     }
 
     override fun renderComposerMode(mode: MessageComposerMode) {
+        if (this.composerMode == mode) return
+        this.composerMode = mode
+
         if (mode is MessageComposerMode.Special) {
             views.composerModeGroup.isVisible = true
             replaceFormattedContent(mode.defaultContent)

--- a/libraries/textcomposer/src/main/java/io/element/android/x/textcomposer/TextComposer.kt
+++ b/libraries/textcomposer/src/main/java/io/element/android/x/textcomposer/TextComposer.kt
@@ -71,7 +71,7 @@ fun TextComposer(
                     }
 
                 }
-                setFullScreen(fullscreen, true)
+                setFullScreen(fullscreen, animated = false, manageKeyboard = true)
                 (this as MessageComposerView).apply {
                     setup(isInDarkMode, composerMode)
                 }
@@ -85,8 +85,9 @@ fun TextComposer(
             // whenever the state changes
             // Example of Compose -> View communication
             val messageComposerView = (view as MessageComposerView)
-            view.setFullScreen(fullscreen, false)
-            // TODO messageComposerView.renderComposerMode(composerMode)
+            view.setFullScreen(fullscreen, animated = false, manageKeyboard = false)
+            // TODO: un-comment once we update to a version of the lib > 0.8.0
+            // messageComposerView.renderComposerMode(composerMode)
             messageComposerView.sendButton.isInvisible = !composerCanSendMessage
             messageComposerView.setTextIfDifferent(composerText ?: "")
         }
@@ -122,7 +123,9 @@ private fun MessageComposerView.setup(isDarkMode: Boolean, composerMode: Message
     editText.setHint(ElementR.string.room_message_placeholder)
     emojiButton?.isVisible = true
     sendButton.isVisible = true
-    // TODO renderComposerMode(composerMode)
+    editText.maxLines = MessageComposerView.MAX_LINES_WHEN_COLLAPSED
+    // TODO: un-comment once we update to a version of the lib > 0.8.0
+    // renderComposerMode(composerMode)
 }
 
 @Preview


### PR DESCRIPTION
Note: this will only be noticeable once a new version of the RTE library is used and the crash when calling `renderComposerMode` is fixed.

Also, improved the UI for full screen mode.

Its Element Android counterpart is https://github.com/vector-im/element-android/pull/7691.